### PR TITLE
chore: removed engines from package and updated ci testing to Node LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
       script:
         - npm run test
       node_js:
-        - 14.3.0
+        - lts/*
     - stage: doc
       node_js: lts/*
       skip_cleanup: 'true'

--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
     "svelte": "^3.22.3",
     "testcafe": "^1.8.5"
   },
-  "engines": {
-    "node": ">=14.3.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/arlac77/svelte-session-manager.git"


### PR DESCRIPTION
As raised in #218 this PR removes engines from package.json and updates Travis to test against Node LTS.