### PR TITLE
merge from svelte-session-manager,template-svelte-component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-bundle.*
 /node_modules/**
 *.log
 *.dump
+bundle.*
 build
 .DS_Store
 *.node

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
+rollup.config.*
 build
 tests
-rollup.config.*
 doc
 *.log
 *.tmp
@@ -11,3 +11,4 @@ doc
 .github
 netlify.toml
 jsconfig.json
+vite.config.js

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "log",
     "session",
     "svelte",
+    "vite",
     "web"
   ],
   "contributors": [
@@ -22,34 +23,34 @@
   ],
   "license": "BSD-2-Clause",
   "scripts": {
-    "start": "rollup -c tests/app/rollup.config.mjs -w",
+    "prepare": "vite build",
+    "start": "vite",
     "test": "npm run test:ava && npm run test:cafe",
-    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*.js -s build/test --page-request-timeout 9000 --app-init-delay 3000 --app \"rollup -c tests/app/rollup.config.mjs -w\"",
+    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*.js -s build/test --page-request-timeout 3000 --app-init-delay 3000 --app \"rollup -c tests/app/rollup.config.mjs -w\"",
     "test:ava": "ava --timeout 2m tests/*.mjs",
     "cover": "c8 -x 'tests/**/*' --temp-directory build/tmp ava --timeout 2m tests/*.mjs && c8 report -r lcov -o build/coverage --temp-directory build/tmp",
     "docs": "documentation readme --section=API ./src/**/*.mjs",
     "lint": "npm run lint:docs",
     "lint:docs": "documentation lint ./src/**/*.mjs",
-    "build": "rollup -c tests/app/rollup.config.mjs"
+    "build": "rollup -c tests/app/rollup.config.mjs",
+    "preview": "vite preview"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-virtual": "^2.1.0",
+    "@sveltejs/vite-plugin-svelte": "^1.0.1",
     "ava": "^4.3.1",
-    "c8": "^7.11.3",
+    "c8": "^7.12.0",
     "documentation": "^13.2.5",
     "jsonwebtoken": "^8.5.1",
     "mf-styling": "^1.2.44",
-    "postcss": "^8.4.14",
-    "postcss-import": "^14.1.0",
     "reader-line-iterator": "^1.1.2",
-    "rollup": "^2.77.0",
+    "rollup": "^2.77.2",
     "rollup-plugin-dev": "^2.0.3",
-    "rollup-plugin-postcss": "^4.0.2",
-    "rollup-plugin-svelte": "^7.1.0",
     "semantic-release": "^19.0.3",
     "svelte": "^3.49.0",
-    "testcafe": "^1.19.0"
+    "testcafe": "^1.20.0",
+    "vite": "^3.0.4"
   },
   "repository": {
     "type": "git",
@@ -59,6 +60,9 @@
     "url": "https://github.com/arlac77/svelte-session-manager/issues"
   },
   "homepage": "https://github.com/arlac77/svelte-session-manager#readme",
+  "pkgbuild": {
+    "groups": "examples"
+  },
   "template": {
     "properties": {
       "netlifly": {
@@ -71,7 +75,7 @@
       "arlac77/template-arlac77-github",
       "arlac77/template-ava-coverage",
       "arlac77/template-cloudflare",
-      "arlac77/template-svelte-component"
+      "arlac77/template-svelte-component#next"
     ]
   }
 }

--- a/tests/app/src/index.html
+++ b/tests/app/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    {{html.base.href}}
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <script defer src="./index.mjs" type="module"></script>
+    <link rel="stylesheet" href="./main.css" />
+    <title>svelte-session-manager Example</title>
+  </head>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,43 @@
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { defineConfig } from "vite";
+
+export default defineConfig(async ({ command, mode }) => {
+  const { extractFromPackage } = await import(
+    new URL("node_modules/npm-pkgbuild/src/module.mjs", import.meta.url)
+  );
+  const res = extractFromPackage({
+    dir: new URL("./", import.meta.url).pathname
+  });
+  const first = await res.next();
+  const pkg = first.value;
+  const properties = pkg.properties;
+  const base = properties["http.path"] + "/";
+  const production = mode === "production";
+
+  process.env["VITE_NAME"] = properties.name;
+  process.env["VITE_DESCRIPTION"] = properties.description;
+  process.env["VITE_VERSION"] = properties.version;
+
+  const open = process.env.CI ? {} : { open: base };
+
+  return {
+    base,
+    root: "tests/app/src",
+    worker: { format: "es" },
+    plugins: [
+      svelte({
+        compilerOptions: {
+          dev: !production
+        }
+      })
+    ],
+    server: { host: true, ...open },
+    build: {
+      outDir: "../../../build",
+      target: "esnext",
+      emptyOutDir: true,
+      minify: production,
+      sourcemap: true
+    }
+  };
+});


### PR DESCRIPTION
package.json
---
- chore(package): add vite (keywords)
chore(scripts): add vite (scripts.start)
chore(scripts): add testcafe $BROWSER:headless tests/cafe/*.js -s build/test --page-request-timeout 3000 --app-init-delay 3000 --app "rollup -c tests/app/rollup.config.mjs -w" (scripts.test:cafe)
chore(scripts): add vite build (scripts.prepare)
chore(scripts): add vite preview (scripts.preview)
chore(deps): add ^7.12.0 remove ^7.11.3 (devDependencies.c8)
chore(deps): remove ^8.4.14 (devDependencies.postcss)
chore(deps): remove ^14.1.0 (devDependencies.postcss-import)
chore(deps): add ^2.77.2 remove ^2.77.0 (devDependencies.rollup)
chore(deps): remove ^4.0.2 (devDependencies.rollup-plugin-postcss)
chore(deps): remove ^7.1.0 (devDependencies.rollup-plugin-svelte)
chore(deps): add ^1.20.0 remove ^1.19.0 (devDependencies.testcafe)
chore(deps): add ^1.0.1 (devDependencies.@sveltejs/vite-plugin-svelte)
chore(deps): add ^3.0.4 (devDependencies.vite)
chore(package): (pkgbuild)

.npmignore
---
- chore: add vite.config.js ()
chore: remove rollup.config.* ()
chore: add rollup.config.* ()

.gitignore
---
- chore: remove bundle.* ()
chore: add bundle.* ()

tests/app/src/index.html
---
- add missing tests/app/src/index.html from template

vite.config.js
---
- add missing vite.config.js from template

